### PR TITLE
Fix requirements trailing newline

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,4 +33,4 @@ redis>=5.0.0
 pytest>=7.4.0
 pytest-asyncio>=0.21.0
 black>=23.0.0
-flake8>=6.0.0 
+flake8>=6.0.0


### PR DESCRIPTION
## Summary
- ensure `backend/requirements.txt` ends with a newline without trailing spaces

## Testing
- `tail -n 1 backend/requirements.txt | od -c`
